### PR TITLE
curl: Adds curl to C:\Windows\System32

### DIFF
--- a/curl/Dockerfile.servercore.1709
+++ b/curl/Dockerfile.servercore.1709
@@ -5,6 +5,6 @@ ADD https://skanthak.homepage.t-online.de/download/curl-$CURL_VERSION.cab curl.c
 RUN expand /R curl.cab /F:* .
 
 FROM microsoft/windowsservercore:1709
-COPY --from=download /curl/AMD64/ /
-COPY --from=download /curl/CURL.LIC /
+COPY --from=download /curl/AMD64/ /Windows/System32/
+COPY --from=download /curl/CURL.LIC /Windows/System32/
 ENTRYPOINT ["curl.exe"]


### PR DESCRIPTION
C:\Windows\System32 is in PATH, which is required for calling
curl directly, without passing its direct path.

In some cases, this is required. (executing curl when not in C:\)