### PR TITLE
hostexec: Adds sleep on start

### DIFF
--- a/hostexec/Dockerfile_win
+++ b/hostexec/Dockerfile_win
@@ -1,1 +1,2 @@
 FROM atuvenie/busybox:1.24
+ENTRYPOINT ["cmd.exe", "/s", "/c", "sleep", "3600"]


### PR DESCRIPTION
hostexec should not Terminate immediately after it starts, since
some kubernetes tests will try to execute some commands inside the
containers.