### PR TITLE
netexec: Bases image on busybox

### DIFF
--- a/netexec/Dockerfile.servercore.1709
+++ b/netexec/Dockerfile.servercore.1709
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1709
+FROM atuvenie/busybox:1.24
 ADD netexec.exe netexec.exe
 EXPOSE 8080
 EXPOSE 8081


### PR DESCRIPTION
Some tests require Linux specific commands (e.g.: sleep).