### PR TITLE
Fixes dnsutils and jessie-dnsutils base image reference

### DIFF
--- a/dnsutils/Dockerfile.servercore.1709
+++ b/dnsutils/Dockerfile.servercore.1709
@@ -1,4 +1,4 @@
-FROM atuvenie/busybox:1.0
+FROM atuvenie/busybox:1.24
 USER ContainerAdministrator
 ENV chocolateyUseWindowsCompression false
 RUN powershell -Command \

--- a/jessie-dnsutils/Dockerfile.servercore.1709
+++ b/jessie-dnsutils/Dockerfile.servercore.1709
@@ -1,4 +1,4 @@
-FROM atuvenie/busybox:1.0
+FROM atuvenie/busybox:1.24
 USER ContainerAdministrator
 ENV chocolateyUseWindowsCompression false
 RUN powershell -Command \


### PR DESCRIPTION
busybox:1.24 should be used instead.