### PR TITLE
Fixes netexec image

### DIFF
--- a/netexec/Dockerfile
+++ b/netexec/Dockerfile
@@ -1,5 +1,5 @@
 FROM atuvenie/busybox:1.24
-ADD netexec.exe netexec.exe
+ADD netexec.exe /netexec.exe
 EXPOSE 8080
 EXPOSE 8081
 RUN mkdir uploads


### PR DESCRIPTION
The netexec image is based on busybox, which sets the WORKDIR to C:\busybox. Because of this, the ADD command is currently adding the netexec.exe file into the busybox folder, and the entrypoint expects it to be in the root folder.

This patch fixes this issue by adding the file to the root folder.