### PR TITLE
Fixes mounttest image and executable

### DIFF
--- a/mounttest/Dockerfile
+++ b/mounttest/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=microsoft/windowsservercore:1803
 FROM $BASE_IMAGE
 
-COPY mounttest.exe /mounttest
+COPY mt.exe /mounttest
 COPY filePermissions.ps1 /filePermissions.ps1
 ENTRYPOINT ["/mounttest"]

--- a/mounttest/filePermissions.ps1
+++ b/mounttest/filePermissions.ps1
@@ -19,8 +19,8 @@ function GetFilePermissions($path) {
 
     if ($output.ReturnValue -ne 0) {
         $retVal = $output.ReturnValue
-        echo "GetSecurityDescriptor invocation failed with code: $retVal"
-        exit $output.ReturnValue
+        Write-Error "GetSecurityDescriptor invocation failed with code: $retVal"
+        exit 1
     }
 
     $fileSD = $output.Descriptor
@@ -63,6 +63,9 @@ function GetFilePermissions($path) {
 }
 
 $mask = GetFilePermissions($FileName)
+if (-not $?) {
+    exit 1
+}
 
 # print the permission mask Linux-style.
 echo "0$mask"

--- a/mounttest/mt.go
+++ b/mounttest/mt.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -156,7 +157,7 @@ func readWriteNewFile(path string, perm os.FileMode) error {
 		return nil
 	}
 
-	fullPath := resolveFilePath(path)
+	fullPath, _ := filepath.Abs(path)
 	err := ioutil.WriteFile(fullPath, []byte(initialContent), perm)
 	if err != nil {
 		fmt.Printf("error writing new file %q: %v\n", path, err)


### PR DESCRIPTION
Previously, symlinks did not work properly in the Windows containers, so
we had to work around them, but it's no longer the case since they now
work as intended. Removed resolveFilePath, filepath.Abs will be used
instead (some paths may still be Linux-style, and we need the full
Windows-style paths).

Adds better error handling in the powershell script and mt executable.

Fixes Dockerfile (the BuildImages.ps1 script generates mt.exe binary,
while the Dockerfile expects mounttest.exe).