### PR TITLE
Bases images on e2eteam repository

### DIFF
--- a/busybox/Dockerfile
+++ b/busybox/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=microsoft/windowsservercore:1803
-FROM atuvenie/curl:1803 AS prep
+FROM e2eteam/curl:1803 AS prep
 FROM $BASE_IMAGE
 
 COPY --from=prep /curl/ /curl

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -1,4 +1,5 @@
-FROM e2eteam/java:openjdk-8-jre
+ARG BASE_IMAGE=e2eteam/java:openjdk-8-jre
+FROM $BASE_IMAGE
 
 # install CassandraDB.
 ENV CASSANDRA_VERSION 3.11.2

--- a/dnsutils/Dockerfile
+++ b/dnsutils/Dockerfile
@@ -1,4 +1,5 @@
-FROM atuvenie/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 USER ContainerAdministrator
 ENV chocolateyUseWindowsCompression false
 RUN powershell -Command \

--- a/hostexec/Dockerfile
+++ b/hostexec/Dockerfile
@@ -1,2 +1,3 @@
-FROM atuvenie/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 ENTRYPOINT ["cmd.exe", "/s", "/c", "sleep", "3600"]

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,5 @@
-FROM e2eteam/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 
 # this might take a while. fetching Java takes longer since it's hosted on github.
 ENV JAVA_URL "http://github.com/ojdkbuild/ojdkbuild/releases/download/1.8.0.171-1/java-1.8.0-openjdk-1.8.0.171-1.b10.ojdkbuild.windows.x86_64.zip"

--- a/jessie-dnsutils/Dockerfile
+++ b/jessie-dnsutils/Dockerfile
@@ -1,4 +1,5 @@
-FROM atuvenie/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 USER ContainerAdministrator
 ENV chocolateyUseWindowsCompression false
 RUN powershell -Command \

--- a/kitten/Dockerfile
+++ b/kitten/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM atuvenie/test-webserver:1.0
+ARG BASE_IMAGE=e2eteam/test-webserver:1.0
+FROM $BASE_IMAGE
 COPY html/kitten.jpg kitten.jpg
 COPY html/data.json data.json

--- a/nautilus/Dockerfile
+++ b/nautilus/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM atuvenie/test-webserver:1.0
+ARG BASE_IMAGE=e2eteam/test-webserver:1.0
+FROM $BASE_IMAGE
 COPY html/nautilus.jpg nautilus.jpg
 COPY html/data.json data.json

--- a/net/Dockerfile
+++ b/net/Dockerfile
@@ -1,4 +1,5 @@
-FROM atuvenie/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 ADD net.exe /net
 USER ContainerAdministrator
 RUN powershell -Command \

--- a/netexec/Dockerfile
+++ b/netexec/Dockerfile
@@ -1,4 +1,5 @@
-FROM atuvenie/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 ADD netexec.exe /netexec.exe
 EXPOSE 8080
 EXPOSE 8081

--- a/nginx-slim/Dockerfile
+++ b/nginx-slim/Dockerfile
@@ -1,4 +1,5 @@
-FROM atuvenie/busybox:1.24
+ARG BASE_IMAGE=e2eteam/busybox:1.24
+FROM $BASE_IMAGE
 RUN mkdir c:\build\nginx\source &&\
 powershell -Command "wget -uri 'http://nginx.org/download/nginx-1.9.3.zip' -OutFile 'c:\nginx-1.9.3.zip'" &&\
 powershell -Command "Expand-Archive -Path C:\nginx-1.9.3.zip -DestinationPath C:\nginx -Force" &&\


### PR DESCRIPTION
Some images still use other repositories for base images (e.g.:
atuvenie/busybox:1.24), while the default repository is e2eteam.

Refactors BuildImages.ps1.