### PR TITLE
Pins bind-toolsonly version to 9.10.3

### DIFF
--- a/dnsutils/Dockerfile
+++ b/dnsutils/Dockerfile
@@ -6,5 +6,5 @@ RUN powershell -Command \
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
 choco feature disable --name showDownloadProgress
 ADD hostname.exe /busybox/hostname
-RUN powershell -Command choco install bind-toolsonly -y
+RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
 ENTRYPOINT ["cmd.exe", "/s", "/c"]

--- a/jessie-dnsutils/Dockerfile
+++ b/jessie-dnsutils/Dockerfile
@@ -6,5 +6,5 @@ RUN powershell -Command \
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
 choco feature disable --name showDownloadProgress
 ADD hostname.exe /busybox/hostname
-RUN powershell -Command choco install bind-toolsonly -y
+RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
 ENTRYPOINT ["cmd.exe", "/s", "/c"]


### PR DESCRIPTION
The latest release (9.12.1) has an issue regarding dig: it won't use the
OS' configured DNS servers, causing its queries to fail.

Pinning it to an earlier version fixes the issue.