### PR TITLE
Fixes guestbook application

### DIFF
--- a/gb-frontend/Dockerfile
+++ b/gb-frontend/Dockerfile
@@ -25,4 +25,5 @@ ADD guestbook.php /Users/ContainerAdministrator/AppData/Roaming/Apache24/htdocs/
 ADD controllers.js /Users/ContainerAdministrator/AppData/Roaming/Apache24/htdocs/controllers.js
 ADD index.html /Users/ContainerAdministrator/AppData/Roaming/Apache24/htdocs/index.html
 COPY run.ps1 run.ps1
-CMD .\run.ps1
+USER ContainerAdministrator
+CMD ["powershell", "-Command", "/run.ps1"]

--- a/gb-frontend/run.ps1
+++ b/gb-frontend/run.ps1
@@ -1,2 +1,20 @@
+# there are some issues with DNS name resolution, so we're going to bypass them.
+# guestbook will try to contact redis-master and redis-slave, so we'll insert
+# those entries into the hosts file, if we can.
+if (Test-Path C:\var\run\secrets\kubernetes.io\serviceaccount\namespace) {
+    # we're running inside a kubernetes pod, and we have the namespace.
+    Write-Host "We're running inside a kubernetes pod."
+
+    $namespace = Get-Content C:\var\run\secrets\kubernetes.io\serviceaccount\namespace
+
+    $redisMasterIps = Resolve-DnsName redis-master.$namespace`.svc.cluster.local
+    $ip = $redisMasterIps[0].IPAddress
+    Add-Content -Value "$ip redis-master" -Path C:\Windows\System32\drivers\etc\hosts
+
+    $redisSlaveIps = Resolve-DnsName redis-slave.$namespace`.svc.cluster.local
+    $ip = $redisSlaveIps[0].IPAddress
+    Add-Content -Value "$ip redis-slave" -Path C:\Windows\System32\drivers\etc\hosts
+}
+
 Stop-Process -Name httpd -Force
-& "c:/Users/ContainerAdministrator/AppData/Roaming/Apache24/bin/httpd.exe -t"
+c:/Users/ContainerAdministrator/AppData/Roaming/Apache24/bin/httpd.exe

--- a/gb-redisslave/Dockerfile
+++ b/gb-redisslave/Dockerfile
@@ -7,8 +7,9 @@ RUN powershell -Command \
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12 ; \
 Invoke-WebRequest -Method Get -Uri https://github.com/MSOpenTech/redis/releases/download/win-3.2.100/Redis-x64-3.2.100.zip -OutFile redis.zip ; \
 Expand-Archive redis.zip . ; \
-Remove-Item redis.zip -Force
-COPY redis.conf ./redis.windows-service.conf
+Remove-Item redis.zip -Force ; \
+mkdir C:\data
 COPY redis.conf ./redis.windows.conf
-COPY run.ps1 run.ps1
-CMD .\run.ps1
+COPY run.ps1 /run.ps1
+USER ContainerAdministrator
+CMD ["powershell", "-Command", "/run.ps1"]

--- a/gb-redisslave/run.ps1
+++ b/gb-redisslave/run.ps1
@@ -1,9 +1,24 @@
+# there are some issues with DNS name resolution, so we're going to bypass them.
+# Redis will try to contact redis-master, so we'll insert that entry into the
+# hosts file, if we can.
+if (Test-Path C:\var\run\secrets\kubernetes.io\serviceaccount\namespace) {
+    # we're running inside a kubernetes pod, and we have the namespace.
+    Write-Host "We're running inside a kubernetes pod."
+
+    $namespace = Get-Content C:\var\run\secrets\kubernetes.io\serviceaccount\namespace
+
+    $redisMasterIps = Resolve-DnsName redis-master.$namespace`.svc.cluster.local
+    $ip = $redisMasterIps[0].IPAddress
+    Add-Content -Value "$ip redis-master" -Path C:\Windows\System32\drivers\etc\hosts
+}
+
 if (-not (Test-Path env:GET_HOSTS_FROM)) { $env:GET_HOSTS_FROM = 'dns' }
-if (Get-Childitem Env:GET_HOSTS_FROM) -eq "env") {
+
+if ((Get-Childitem Env:GET_HOSTS_FROM) -eq "env") {
   if (Test-Path env:REDIS_MASTER_SERVICE_HOST) {
-  & "C:\redis\redis-server.exe" --slaveof $(Get-Childitem Env:REDIS_MASTER_SERVICE_HOST) 6379
+    C:\redis\redis-server.exe C:\redis\redis.windows.conf --slaveof $(Get-Childitem Env:REDIS_MASTER_SERVICE_HOST) 6379
   }
 }
 else{
- & "C:\redis\redis-server.exe" --slaveof redis-master 6379
+    C:\redis\redis-server.exe C:\redis\redis.windows.conf --slaveof redis-master 6379
  }

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -6,7 +6,7 @@ RUN powershell -Command \
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12 ; \
 Invoke-WebRequest -Method Get -Uri https://github.com/MSOpenTech/redis/releases/download/win-3.2.100/Redis-x64-3.2.100.zip -OutFile redis.zip ; \
 Expand-Archive redis.zip . ; \
-Remove-Item redis.zip -Force
-COPY redis.conf ./redis.windows-service.conf
+Remove-Item redis.zip -Force ; \
+mkdir C:\data
 COPY redis.conf ./redis.windows.conf
-CMD redis-server
+CMD ["redis-server", "redis.windows.conf"]


### PR DESCRIPTION
The guestbook app deploys 3 types of containers: gb-frontend,
gb-redisslave, and redis. They all had various issues, causing the app
not to work properly:

1. DNS resolution: gb-frontend and gb-redisslave tries to connect to redis
and gb-redisslave through DNS name. But if DNS suffix is wrong, they
won't be able to connect. In the case of Kubernetes, host entries will
be added for redis-slave and and redis-master for the containers, so
they will be able to resolve the names.

2. run.ps1 was not being executed.

3. Redis was not being started using the added config value, starting in
protected mode, refusing all connections.